### PR TITLE
Do not panic on invalid input

### DIFF
--- a/crates/bloom/src/filter/bloom.rs
+++ b/crates/bloom/src/filter/bloom.rs
@@ -22,15 +22,17 @@ impl BloomFilter {
                     items_count: Some(items_count),
                     fp_rate: Some(fp_rate),
                     ..
-                } => Bloom::new_for_fp_rate(items_count, fp_rate),
+                } if items_count > 0 && fp_rate > 0.0 && fp_rate < 1.0 => {
+                    Bloom::new_for_fp_rate(items_count, fp_rate)
+                }
                 FilterOptions {
                     bitmap_size: Some(bitmap_size),
                     items_count: Some(items_count),
                     ..
-                } => Bloom::new(bitmap_size, items_count),
+                } if bitmap_size > 0 && items_count > 0 => Bloom::new(bitmap_size, items_count),
                 _ => {
                     return Err(format!(
-                        "must set `items_count` AND (`fp_rate` OR `bitmap_size`)], got {:?}",
+                        "must set `items_count > 0` AND (`1.0 > fp_rate > 0.0` OR `bitmap_size > 0`)], got {:?}",
                         opts
                     ))
                 }

--- a/crates/bloom/src/filter/forgetful.rs
+++ b/crates/bloom/src/filter/forgetful.rs
@@ -29,16 +29,16 @@ impl ForgetfulFilter {
                     items_count: Some(items_count),
                     fp_rate: None,
                     ..
-                } => Bloom::new(bitmap_size, items_count),
+                } if bitmap_size > 0 && items_count > 0 => Bloom::new(bitmap_size, items_count),
                 FilterOptions {
                     bitmap_size: None,
                     items_count: Some(items_count),
                     fp_rate: Some(fp_rate),
                     ..
-                } => Bloom::new_for_fp_rate(items_count, fp_rate),
+                } if items_count > 0 && fp_rate > 0.0 && fp_rate < 1.0 => Bloom::new_for_fp_rate(items_count, fp_rate),
                 _ => {
                     return Err(format!(
-                        "must set `items_count` AND (`fp_rate` OR `bitmap_size`)], got {:?}",
+                        "must set `items_count > 0` AND (`1.0 > fp_rate > 0.0` OR `bitmap_size > 0`)], got {:?}",
                         opts
                     ))
                 }


### PR DESCRIPTION
The upstream bloom crate we depend on panics when `items_count == 0`, `bitmap_size == 0`, `fp_rate == 0.0`, or `fp_rate == 1.0`. This would _kind of_ makes sense, but only if it was documented, which it isn't.

To save debugging Erlang pattern mismatches, and remove the overhead of stack-unwinding, let's return an explicit error.